### PR TITLE
Implement basic render and close in _MinimalGymEnv

### DIFF
--- a/DiaGuardianAI/agents/decision_agent.py
+++ b/DiaGuardianAI/agents/decision_agent.py
@@ -66,10 +66,13 @@ class _MinimalGymEnv(gym.Env):
         return self.current_obs, {}
 
     def render(self):
-        pass # Placeholder
+        """Render the current observation to the console."""
+        print(f"Current observation: {self.current_obs}")
 
     def close(self):
-        pass # Placeholder
+        """Perform minimal environment cleanup."""
+        # Nothing persistent to clean up, but method provided for completeness
+        print("_MinimalGymEnv closed.")
 
 
 class RLAgent(BaseAgent):


### PR DESCRIPTION
## Summary
- show the observation when rendering the DecisionAgent's minimal gym environment
- log a closing message in the environment's `close()` method

## Testing
- `pytest -q` *(fails: SyntheticPatient.step() argument errors and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68568ded04e48323a97332ce202a0591