### PR TITLE
Add new tests for updated components

### DIFF
--- a/tests/new_tests/test_ensemble_predictor_outputs.py
+++ b/tests/new_tests/test_ensemble_predictor_outputs.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import numpy as np
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from DiaGuardianAI.predictive_models.model_zoo.ensemble_predictor import EnsemblePredictor
+from DiaGuardianAI.core.base_classes import BasePredictiveModel
+
+class DummyModel(BasePredictiveModel):
+    def __init__(self, value, length=3):
+        self.value = value
+        self.length = length
+    def train(self, data, targets=None, **kwargs):
+        pass
+    def predict(self, current_input, **kwargs):
+        mean = [self.value for _ in range(self.length)]
+        std = [0.1 * self.value for _ in range(self.length)]
+        return {"mean": mean, "std_dev": std}
+    def save(self, path):
+        pass
+    def load(self, path):
+        pass
+
+def test_ensemble_average_strategy():
+    models = [DummyModel(100), DummyModel(110)]
+    ensemble = EnsemblePredictor(models=models, strategy="average")
+    preds = ensemble.predict(None)
+    assert preds["mean"] == [105.0, 105.0, 105.0]
+    assert all(isinstance(v, float) for v in preds["std_dev"])
+
+
+def test_ensemble_weighted_average_strategy():
+    models = [DummyModel(80), DummyModel(120)]
+    ensemble = EnsemblePredictor(models=models, strategy="weighted_average", weights=[0.25, 0.75])
+    preds = ensemble.predict(None)
+    expected = 80*0.25 + 120*0.75
+    assert preds["mean"][0] == expected

--- a/tests/new_tests/test_federated_learning_workflow.py
+++ b/tests/new_tests/test_federated_learning_workflow.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from DiaGuardianAI.learning.federated_learning import FederatedClient
+
+class SimpleModel:
+    def __init__(self):
+        self.updated = False
+
+
+def dummy_server_callback(model):
+    model.updated = True
+
+
+def test_federated_client_workflow():
+    model = SimpleModel()
+    client = FederatedClient(model=model, client_id="c1", server_callback=dummy_server_callback, buffer_capacity=10)
+    data = [1, 2, 3]
+    client.train_local(data)
+    assert len(client.replay_buffer) == 3
+    client.continual_update(batch_size=2)
+    client.share_updates()
+    assert model.updated is True

--- a/tests/new_tests/test_meal_detector_accuracy.py
+++ b/tests/new_tests/test_meal_detector_accuracy.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from DiaGuardianAI.agents.meal_detector import MealDetector
+
+
+def test_meal_detector_rule_based_detects_meal():
+    detector = MealDetector(
+        detection_method="rule_based",
+        params={"rise_threshold_mg_dl": 20, "time_window_minutes": 30, "min_samples_in_window": 3}
+    )
+    start = datetime(2023, 1, 1, 12, 0)
+    cgm_history = [100, 105, 115, 130]
+    timestamps = [start + timedelta(minutes=5*i) for i in range(len(cgm_history))]
+    prob, est_time, carbs = detector.detect_meal_event(cgm_history, timestamps)
+    assert prob > 0.5
+    assert est_time == timestamps[0]
+    assert carbs is not None
+
+
+def test_meal_detector_rule_based_no_meal():
+    detector = MealDetector(
+        detection_method="rule_based",
+        params={"rise_threshold_mg_dl": 25, "time_window_minutes": 30, "min_samples_in_window": 3}
+    )
+    start = datetime(2023, 1, 1, 12, 0)
+    cgm_history = [100, 102, 101, 103]
+    timestamps = [start + timedelta(minutes=5*i) for i in range(len(cgm_history))]
+    prob, est_time, carbs = detector.detect_meal_event(cgm_history, timestamps)
+    assert prob == 0.0
+    assert est_time is None
+    assert carbs is None


### PR DESCRIPTION
## Summary
- add tests for meal detector rule-based accuracy
- add ensemble predictor averaging tests
- add federated client workflow tests
- fix imports for new tests

## Testing
- `pytest tests/new_tests -q`
- `pytest -q` *(fails: PatternAdvisorAgent and other legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_6863e53909f8832387508eaf0f9d759b