### PR TITLE
Drop sqlite3 from requirements and add basic CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,6 @@ scipy>=1.10.0
 joblib>=1.3.0
 tqdm>=4.65.0
 
-# Database
-sqlite3
-
 # Optional: For advanced features
 # streamlit>=1.28.0  # For clinical demo
 # plotly>=5.15.0     # For visualizations


### PR DESCRIPTION
## Summary
- drop builtin sqlite3 from requirements.txt
- run tests in GitHub Actions and install dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f92a73f88323a3326422105d80e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated testing for Python code using GitHub Actions, running tests on pushes and pull requests to the main branch.

* **Refactor**
  * Removed the commented "Database" section and the `sqlite3` dependency from the requirements list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->