### PR TITLE
Fix duplicate json import

### DIFF
--- a/DiaGuardianAI/agents/pattern_advisor_agent.py
+++ b/DiaGuardianAI/agents/pattern_advisor_agent.py
@@ -35,7 +35,6 @@ from sklearn.neural_network import MLPRegressor  # Added for regression
 from sklearn.ensemble import GradientBoostingRegressor  # Added for regression
 from sklearn.preprocessing import LabelEncoder  # Added import
 import joblib  # For saving/loading sklearn models
-import json  # For saving/loading metadata
 
 _T_PatternAdvisorAgent = TypeVar("_T_PatternAdvisorAgent", bound="PatternAdvisorAgent")
 


### PR DESCRIPTION
## Summary
- remove redundant json import from `pattern_advisor_agent.py`

## Testing
- `pytest -k pattern_advisor_agent -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f927c2bc8323849340dabbfc76bc